### PR TITLE
Fix `symbol __gnu_h2f_ieee undefined` errors

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [unstable]
 build-std = ["core", "compiler_builtins", "alloc"]
-build-std-features = ["compiler-builtins-mem"]
+build-std-features = ["compiler-builtins-mem", "compiler-builtins-no-f16-f128"]
 
 [build]
 rustflags = ["-C", "panic=abort"]

--- a/drivers/hello/.cargo/config.toml
+++ b/drivers/hello/.cargo/config.toml
@@ -1,6 +1,6 @@
 [unstable]
 build-std = ["core", "compiler_builtins"]
-build-std-features = ["compiler-builtins-mem"]
+build-std-features = ["compiler-builtins-mem", "compiler-builtins-no-f16-f128"]
 
 [build]
 target = "../../kernel/x86_64-kernel-freebsd.json"

--- a/drivers/hello/rust-toolchain.toml
+++ b/drivers/hello/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+channel = "nightly-2025-05-18"
+components = [
+    "rustfmt",
+    "clippy",
+    "rust-src",
+]

--- a/kernel/.cargo/config.toml
+++ b/kernel/.cargo/config.toml
@@ -8,4 +8,4 @@ rustflags = [
 
 [unstable]
 build-std = ["core", "compiler_builtins", "alloc"]
-build-std-features = ["compiler-builtins-mem"]
+build-std-features = ["compiler-builtins-mem", "compiler-builtins-no-f16-f128"]

--- a/kernel/rust-toolchain.toml
+++ b/kernel/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+channel = "nightly-2025-05-18"
+components = [
+    "rustfmt",
+    "clippy",
+    "rust-src",
+]


### PR DESCRIPTION
Rust's current compiler-builtins crate assumes f16 support. But llvm isn't including that, at least not with our current target json configuration. That results in this error when attempting to load the kernel module:

```
link_elf_obj: symbol __gnu_h2f_ieee undefined
linker_load_file: ./hello.ko - unsupported file type
```

Fix this error by pinning the Rust toolchain to an older version that doesn't require f16.  Nightly versions before 2025-05-19 allowed that support to be disabled with a compile-time feature.  Newer versions do not.