### PR TITLE
Move bindgen-generated files into the target/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 kernel/target
-kernel/src/bindings/imports.rs
 
 drivers/**/*.ko
 drivers/**/*.o

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -1,9 +1,6 @@
-extern crate bindgen;
-
 use bindgen::{Builder, MacroTypeVariation::Signed};
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
-const FILEPATH: &str = "src/bindings/imports.rs";
 const HEADERPATH: &str = "headers/wrapper.h";
 
 fn main() {
@@ -24,7 +21,7 @@ fn main() {
         .generate()
         .expect("Unable to generate bindings");
 
-    let out_path = PathBuf::from(FILEPATH);
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("imports.rs");
     bindings
         .write_to_file(out_path)
         .expect("Unable to write bindings");

--- a/kernel/src/bindings/mod.rs
+++ b/kernel/src/bindings/mod.rs
@@ -1,1 +1,4 @@
-pub mod imports;
+#[allow(clippy::missing_safety_doc)]
+pub mod imports {
+    include!(concat!(env!("OUT_DIR"), "/imports.rs"));
+}


### PR DESCRIPTION
Since these files aren't committed to source control and aren't intended to be human-edittable, it makes sense to put them with the object files, not the real source files.  This practice also makes some kinds of tooling easier.