### PR TITLE
fix task build-kmod not found and drivers example tiny bug.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,21 @@
 [workspace]
+resolver = "3"
 members = [
   "kernel",
   "drivers/hello",
   "drivers/char",
+#  "test"
 ]
-resolver = "3"
+[workspace.dependencies]
+kernel = { path = "kernel"}
+
+
+
+[profile.release]
+panic="abort"
+lto = true
+
+[profile.dev]
+panic="abort"
+lto = true
+

--- a/drivers/char/src/lib.rs
+++ b/drivers/char/src/lib.rs
@@ -15,7 +15,7 @@ extern crate alloc;
 ///
 /// This function is in charge of dealing with any incomming module event
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn module_event(
+pub unsafe extern "C" fn char_module_event(
     _mod: *mut module,
     event: i32,
     _arg: *mut c_void,
@@ -44,6 +44,6 @@ pub unsafe extern "C" fn module_event(
 #[unsafe(no_mangle)]
 pub static mut char_mod: moduledata_t = moduledata_t {
     name: c"CharacterDevice".as_ptr(),
-    evhand: Some(module_event),
+    evhand: Some(char_module_event),
     priv_: core::ptr::null_mut(),
 };

--- a/drivers/hello/src/lib.rs
+++ b/drivers/hello/src/lib.rs
@@ -12,7 +12,7 @@ use hello::HelloWorld;
 ///
 /// This function is in charge of dealing with any incomming module event
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn module_event(
+pub unsafe extern "C" fn hello_module_event(
     _mod: *mut module,
     event: i32,
     _arg: *mut c_void,
@@ -35,6 +35,6 @@ pub unsafe extern "C" fn module_event(
 #[unsafe(no_mangle)]
 pub static mut hello_mod: moduledata_t = moduledata_t {
     name: c"hello".as_ptr(),
-    evhand: Some(module_event),
+    evhand: Some(hello_module_event),
     priv_: core::ptr::null_mut(),
 };

--- a/kernel/Makefile.toml
+++ b/kernel/Makefile.toml
@@ -1,0 +1,5 @@
+[tasks.build-kmod]
+command = "make"
+args = ["-C", "/usr/src/sys", "M=${PWD}", "modules"]
+
+dependencies =["build"]


### PR DESCRIPTION
Successfully compiled using "cargo make build-kmod", except for the test directory example.