### PR TITLE
Fix Cirrus CI freebsd-src clone

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,8 +6,6 @@ task:
   freebsd_instance:
     image_family: freebsd-15-0-snap
   setup_script:
-    - ls /usr/src
-    - ls /usr
     - pkg install -y git
     - git clone --depth=1 --branch stable/15 https://github.com/freebsd/freebsd-src.git $HOME/freebsd-src
     - fetch https://sh.rustup.rs -o rustup.sh


### PR DESCRIPTION
Verified that the freebsd15 image doesn't contain /usr/src, then switched the git clone to obtain the stable/15 branch instead of main.